### PR TITLE
Removes requirements from the plugin manifest.

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -20,8 +20,7 @@
     "conversion",
     "sync"
   ],
-  "requirements": {
-    "commands": ["jira-beads-sync"],
-    "plugins": ["beads@beads-marketplace"]
-  }
+  "commands": [
+    "./commands"
+  ]
 }


### PR DESCRIPTION
`requirements` doesn't appear to be a valid plugin manifest key anymore.